### PR TITLE
timeout on cmd vel

### DIFF
--- a/scout_base/src/scout_messenger.cpp
+++ b/scout_base/src/scout_messenger.cpp
@@ -36,6 +36,7 @@ void ScoutROSMessenger::SetupSubscription()
 
 void ScoutROSMessenger::TwistCmdCallback(const geometry_msgs::Twist::ConstPtr &msg)
 {
+    scout_->cmd_msg_received = true; // setting boolean for a received velocity message used for timing in scout_sdk
     if (!simulated_robot_)
     {
         scout_->SetMotionCommand(msg->linear.x, msg->linear.y, msg->angular.z);

--- a/scout_sdk/include/scout_sdk/scout_base.hpp
+++ b/scout_sdk/include/scout_sdk/scout_base.hpp
@@ -25,6 +25,8 @@
 
 #include "scout_sdk/scout_types.hpp"
 
+#include <ros/ros.h>
+
 namespace wescore
 {
 class ScoutBase
@@ -54,6 +56,10 @@ public:
     // light control
     void SetLightCommand(ScoutLightCmd cmd);
     void DisableLightCmdControl();
+
+    bool cmd_msg_received = false; // used to indicate received command vel
+    ros::Time begin =ros::Time::now(); // used for timing
+    ros::Time end =ros::Time::now(); // used for timing
 
     // get robot state
     ScoutState GetScoutState();

--- a/scout_sdk/src/scout_base.cpp
+++ b/scout_sdk/src/scout_base.cpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <ratio>
 #include <thread>
-
+#include <ros/ros.h> 
 namespace
 {
 // source: https://github.com/rxdu/stopwatch
@@ -256,6 +256,21 @@ void ScoutBase::ControlLoop(int32_t period_ms)
             SendLightCmd(light_cmd_count++);
 
         ctrl_sw.sleep_until_ms(period_ms);
+        
+        // reset timing if cmd_vel received
+        if(cmd_msg_received){
+            begin = ros::Time::now();
+            end = ros::Time::now();
+         }
+        
+        // if cmd_vel not received within 0.5 sec, stop the base
+        if((end-begin).toSec()>=0.5){
+            current_motion_cmd_.linear_velocity = 0.0;
+            current_motion_cmd_.angular_velocity = 0.0;
+            ROS_DEBUG("No velcity message received");
+        }
+        cmd_msg_received=false; // reset boolean for receiving cmd_vel
+        end = ros::Time::now(); // continue the timing
         // std::cout << "control loop update frequency: " << 1.0 / ctrl_sw.toc() << std::endl;
     }
 }


### PR DESCRIPTION
On behalf of Chironix Ltd Pty

We found a critical bug with the current cmd_vel interface. It retains the last value received hence the robot keep on driving if the joystick node, for examples, stops running.
We fixed the problem using a timer and tested it on the scout mini.
Please do not hesitate to contact us for further details.